### PR TITLE
feat: pass httpClient by creating new sdk client

### DIFF
--- a/cloudsigma/client.go
+++ b/cloudsigma/client.go
@@ -11,14 +11,14 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/google/go-querystring/query"
 )
 
 const (
+	libraryVersion   = "0.9.0"
 	defaultLocation  = "zrh"
-	defaultUserAgent = "cloudsigma-sdk-go"
+	defaultUserAgent = "cloudsigma-sdk-go/" + libraryVersion
 
 	baseURL         = "https://%s.cloudsigma.com/api/2.0/"
 	headerRequestID = "X-REQUEST-ID"
@@ -106,9 +106,9 @@ type Response struct {
 
 // NewBasicAuthClient returns a new CloudSigma API client. To use API methods provide username (your email)
 // and password.
-func NewBasicAuthClient(username, password string) *Client {
-	httpClient := &http.Client{
-		Timeout: time.Second * 15,
+func NewBasicAuthClient(username, password string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
 	}
 
 	c := &Client{

--- a/cloudsigma/client_test.go
+++ b/cloudsigma/client_test.go
@@ -25,7 +25,7 @@ func setup() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
-	client = NewBasicAuthClient("user", "password")
+	client = NewBasicAuthClient("user", "password", nil)
 	client.APIEndpoint, _ = url.Parse(fmt.Sprintf("%v/", server.URL))
 }
 
@@ -51,7 +51,7 @@ func TestClient_NewBasicAuthClient(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%v/", server.URL), client.APIEndpoint.String())
 	assert.Equal(t, "user", client.Username)
 	assert.Equal(t, "password", client.Password)
-	assert.Equal(t, "cloudsigma-sdk-go", client.UserAgent)
+	assert.Equal(t, defaultUserAgent, client.UserAgent)
 }
 
 func TestClient_SetLocation(t *testing.T) {
@@ -67,9 +67,9 @@ func TestClient_SetUserAgent(t *testing.T) {
 	setup()
 	defer teardown()
 
-	client.SetUserAgent("terraform-provider-cloudsigma")
+	client.SetUserAgent("terraform-provider-cloudsigma/1.1.0-release")
 
-	assert.Equal(t, "terraform-provider-cloudsigma", client.UserAgent)
+	assert.Equal(t, "terraform-provider-cloudsigma/1.1.0-release", client.UserAgent)
 }
 
 func TestClient_NewRequest(t *testing.T) {


### PR DESCRIPTION
This PR allows to specify different timeouts and options by 3rd party integrations when passing custom `http.Client`.