### PR TITLE
fix: change epc 'size' to int

### DIFF
--- a/cloudsigma/servers.go
+++ b/cloudsigma/servers.go
@@ -50,7 +50,7 @@ type ServerDrive struct {
 
 // EnclavePageCache represents a protected memory region for enclaves in a server.
 type EnclavePageCache struct {
-	Size string `json:"size,omitempty"`
+	Size int `json:"size,omitempty"`
 }
 
 // ServerNIC represents a CloudSigma network interface card attached to a server.


### PR DESCRIPTION
This PR changes EPC `size` type from `int` to `string`, because of backend API changes.