### PR TITLE
feat: specify client parameters with option pattern

### DIFF
--- a/cloudsigma/credentials.go
+++ b/cloudsigma/credentials.go
@@ -1,0 +1,85 @@
+package cloudsigma
+
+import (
+	"fmt"
+)
+
+// Credentials is the CloudSigma credentials value for individual credentials
+// fields.
+type Credentials struct {
+	// Source of the credentials.
+	Source string
+
+	// The username (email address) used to communicate with CloudSigma API.
+	Username string
+
+	// The password used to communicate with CloudSigma API.
+	Password string
+
+	// The access token used to communicate with CloudSigma API.
+	Token string
+}
+
+// A CredentialsProvider is the interface for any component which will provide
+// credentials.
+type CredentialsProvider interface {
+	Retrieve() (Credentials, error)
+}
+
+const UsernamePasswordCredentialsName = "UsernamePasswordCredentials"
+
+type UsernamePasswordCredentialsProvider struct {
+	Value Credentials
+}
+
+func NewUsernamePasswordCredentialsProvider(username, password string) UsernamePasswordCredentialsProvider {
+	return UsernamePasswordCredentialsProvider{
+		Value: Credentials{
+			Source:   UsernamePasswordCredentialsName,
+			Username: username,
+			Password: password,
+		},
+	}
+}
+
+func (p UsernamePasswordCredentialsProvider) Retrieve() (Credentials, error) {
+	v := p.Value
+
+	if v.Username == "" {
+		return Credentials{}, fmt.Errorf("username must not be empty")
+	}
+	if v.Password == "" {
+		return Credentials{}, fmt.Errorf("password must not be empty")
+	}
+
+	if v.Source == "" {
+		v.Source = UsernamePasswordCredentialsName
+	}
+
+	return v, nil
+}
+
+const TokenCredentialsName = "TokenCredentials"
+
+type TokenCredentialsProvider struct {
+	Value Credentials
+}
+
+func NewTokenCredentialsProvider(token string) TokenCredentialsProvider {
+	return TokenCredentialsProvider{
+		Value: Credentials{
+			Source: TokenCredentialsName,
+			Token:  token,
+		},
+	}
+}
+
+func (p TokenCredentialsProvider) Retrieve() (Credentials, error) {
+	v := p.Value
+
+	if v.Token == "" {
+		return Credentials{}, fmt.Errorf("token must not be empty")
+	}
+
+	return v, nil
+}

--- a/cloudsigma/errors.go
+++ b/cloudsigma/errors.go
@@ -9,10 +9,10 @@ import (
 var (
 	// ErrEmptyPayloadNotAllowed is returned when a request body is empty
 	// and does not contain a mandatory JSON payload.
-	ErrEmptyPayloadNotAllowed = errors.New("cloudsigma: empty payload not allowed")
+	ErrEmptyPayloadNotAllowed = errors.New("cloudsigma-sdk-go: empty payload not allowed")
 
 	// ErrEmptyArgument is returned when a mandatory function argument is empty.
-	ErrEmptyArgument = errors.New("cloudsigma: argument cannot be empty")
+	ErrEmptyArgument = errors.New("cloudsigma-sdk-go: argument cannot be empty")
 )
 
 // An ErrorResponse reports one or more errors caused by an API request.


### PR DESCRIPTION
This is the breaking change and removes old methods to initialize clients for username/password and token credentials.
`NewClient()` method accept `Credentials` implementation to achieve the desired behaviour, e.g. applying basic auth for request or token with "Bearer ...".