### PR TITLE
chore: update gh-actions to latest stable versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - v*
+      - "v*"
 
 permissions:
   contents: write
@@ -11,18 +11,18 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          cache: true
 
       - name: Install tools
         run: make tools
@@ -31,10 +31,8 @@ jobs:
         run: make test
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
-          args: release -f .github/goreleaser.yaml --rm-dist
-          distribution: goreleaser
-          version: latest
+          args: release -f .github/goreleaser.yaml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - "README.md"
   push:
-    branches: [ master ]
+    branches: [master]
     paths-ignore:
       - "README.md"
 
@@ -15,18 +15,19 @@ permissions:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     strategy:
       matrix:
-        go-version: [ 1.21, 1.22 ]
+        go-version: [1.21, 1.22]
 
     name: unit tests (go ${{ matrix.go-version }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true


### PR DESCRIPTION
This PR updates GitHub Action versions to the latest stable and removes deprecated parameters.